### PR TITLE
runme.sh: install and use runme.sh as ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,16 +32,12 @@ RUN rm /usr/bin/ditaa
 COPY ditaa.sh /usr/bin/ditaa
 RUN chmod 755 /usr/bin/ditaa
 
-# clone the "smithfarm" repo (edit to use YOUR fork and branch)
-RUN git clone -b wip-14070 git://github.com/smithfarm/ceph.git
-
-# build the docs
-WORKDIR /ceph
-RUN admin/build-doc
-
-# configure and run lighty
+# configure lighty
 RUN mv /etc/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf.ORIG
 COPY lighttpd.conf /etc/lighttpd/lighttpd.conf
 EXPOSE 80
 
-CMD lighttpd -D -f /etc/lighttpd/lighttpd.conf
+# hand over to runme.sh
+COPY runme.sh /tmp/runme.sh
+RUN install -o root -g root -m 755 /tmp/runme.sh /runme.sh
+ENTRYPOINT [ "/runme.sh" ]

--- a/README.rst
+++ b/README.rst
@@ -29,16 +29,6 @@ Clone this repo and cd in: ::
     $ git clone git://github.com/smithfarm/ubuntu-ceph-build-docs
     $ cd ubuntu-ceph-build-docs
 
-Edit the Dockerfile. Change the following line so it points to **your**
-fork and branch: ::
-
-    RUN git clone -b wip-14070 git://github.com/smithfarm/ceph.git
-
-If you don't have a fork, you can try building the master docs by changing
-the line to: ::
-
-    RUN git clone -b master git://github.com/ceph/ceph.git
-    
 Build docker image: ::
 
     $ docker build -t ubuntu-ceph-build-docs .
@@ -48,9 +38,31 @@ will be accessible via HTTP - change it to whatever you like): ::
 
     $ docker run -d -p 16289:80 --name cephdoc ubuntu-ceph-build-docs
 
-Test that you can view the docs: ::
+This causes the :code:`runme.sh` script to be run with the defaults,
+meaning that it will build the documentation from the upstream master
+branch. If you would like to build from a different fork and/or branch,
+append either or both of the following arguments to the end of the
+:code:`docker run` command: ::
 
-    $ curl http://localhost:16289
+    --fork $GITHUB_USER
+    --branch $BRANCH
+
+E.g.: ::
+
+    $ docker run -d -p 16289:80 --name cephdoc ubuntu-ceph-build-docs \
+    --fork smithfarm \
+    --branch wip-14070
+
+This will start the container and run the :code:`runme.sh` script inside
+it. Since the script clones the :code:`ceph.git` repo and builds the docs,
+it takes time to complete. Use the following command to monitor progress: ::
+
+    $ docker exec -it cephdoc tail -f runme.out
+
+Once the script finishes, hit CTRL-C to return to your shell prompt. The
+last thing the script does is run :code:`lighttpd` in the container. The
+Ceph documentation that was just built can now be viewed. ::
+
     $ firefox http://localhost:16289
 
 If you are working on the documentation, you can push modifications to the

--- a/runme.sh
+++ b/runme.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# runme.sh
+#
+# Docker entrypoint script for "ceph-workbench review-docs"
+#
+
+OUT=./runme.out
+
+# define usage_exit function
+usage_exit() {
+    echo "usage: $0 [options]"
+    echo "Options:"
+    echo "\t--help / -h    Show this usage message"
+    echo "\t--fork / -f    GitHub username with fork of ceph/ceph.git"
+    echo "\t--branch / -b  Name of branch (in user's fork) to build from"
+    exit
+}
+
+# parse the options
+OPTS=$(getopt -n 'runme.sh' -o 'hf:b:' -l 'help,fork:,branch:' -- "$@")
+if [ $? != 0 ] ; then
+    exit 1
+fi
+eval set -- "$OPTS"
+FORK=ceph
+BRANCH=master
+while echo $1 | grep -q '^-'; do
+    case $1 in
+        -h | --help)
+            usage_exit
+            ;;
+        -f | --fork)
+            shift
+            FORK=$1
+            ;;
+        -b | --branch)
+            shift
+            BRANCH=$1
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            echo unrecognized option \'$1\'
+            usage_exit
+            ;;
+    esac
+    shift
+done
+
+# clone the repo, build the docs
+echo "Cloning http://github.com/$FORK/ceph.git, branch $BRANCH" 2>&1 | tee $OUT
+git clone --progress -b $BRANCH http://github.com/$FORK/ceph.git 2>&1 | tee -a $OUT
+( cd ceph ; exec admin/build-doc ) 2>&1  | tee -a $OUT
+
+# start lighty
+lighttpd -D -f /etc/lighttpd/lighttpd.conf 2>&1 | tee -a $OUT


### PR DESCRIPTION
This is a prerequisite for ceph-workbench integration.

Signed-off-by: Nathan Cutler ncutler@suse.com
